### PR TITLE
fixed gatsby's setup for bit

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -3,7 +3,7 @@
 {
     "header": {
         "scope": "",
-        "version": "0.0.1",
+        "version": "",
         "mainFile": "index.ts",
         "rootDir": "src/components/Header"
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import Header from "@sidharthachatterjee/gatsby.header/dist/Header";
+import Header from "@sidharthachatterjee/gatsby.header";
 
 // markup
 const IndexPage = () => {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -35,8 +35,6 @@
     "policy": {
       "dependencies": {},
       "peerDependencies": {
-        "react": "16.13.1",
-        "react-dom": "16.13.1"
       }
     }
   },


### PR DESCRIPTION
main issue was due to bad react-version deps that bit resolved for the header component.
the component's `package.json` wanted react v16, but only 17 was available... this made Gatsby cry in pain.

steps to see app running:

1. `yarn`
2. `bit link`
3. `bit compile`
4. `yarn start`
5. `bit start` (once this is running, no need to run `bit compile`)

Few notes re-bit's issue in this case:

* components get their own deps. header wanted react 16 due to an issue with dep-resolver
* still beta, so we are already aware of the issue you hit, it's prioritized pretty high
* in this simple starter project it's fine to have Gatsby own deps, but perhaps for more complex setups Bit should be used (note - probably worth discussing about)
* react versioning (and other peer-deps) is a complex thing to manage when sharing components. there are several workflows and apis to help with that (again, might be valuable to have such discussion)